### PR TITLE
removed min content window size to solve scroll to top issues

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -12737,10 +12737,6 @@ body {
           box-shadow: 0 0 20px 0 #cfd2d478;
 }
 
-.main-content {
-  min-height: 900px;
-}
-
 @font-face {
   font-family: 'blokk';
   src: url("/fonts/blokk/blokkneue-regular-webfont.woff2") format("woff2"), url("/fonts/blokk/blokkneue-regular-webfont.woff") format("woff");

--- a/resources/assets/sass/_core-styles.scss
+++ b/resources/assets/sass/_core-styles.scss
@@ -99,10 +99,6 @@ body{
   box-shadow: 0 0 20px 0 #cfd2d478;
 }
 
-.main-content{
-  min-height: 900px;
-}
-
 @font-face {
   font-family: 'blokk';
   src: url('/fonts/blokk/blokkneue-regular-webfont.woff2') format('woff2'),


### PR DESCRIPTION
Having a min-content size of 900px was causing scroll position issues when changing pages.